### PR TITLE
Wrap initial update syncing in a Doc transaction

### DIFF
--- a/src/y-indexeddb.js
+++ b/src/y-indexeddb.js
@@ -15,7 +15,9 @@ export const fetchUpdates = idbPersistence => {
   const [updatesStore] = idb.transact(/** @type {IDBDatabase} */ (idbPersistence.db), [updatesStoreName]) // , 'readonly')
   return idb.getAll(updatesStore, idb.createIDBKeyRangeLowerBound(idbPersistence._dbref, false)).then(updates =>
     idbPersistence._mux(() =>
-      updates.forEach(val => Y.applyUpdate(idbPersistence.doc, val))
+      idbPersistence.doc.transact(() =>
+        updates.forEach(val => Y.applyUpdate(idbPersistence.doc, val))
+      )
     )
   )
     .then(() => idb.getLastKey(updatesStore).then(lastKey => { idbPersistence._dbref = lastKey + 1 }))


### PR DESCRIPTION
While doing some experimentation today, I ran into this behaviour that I found surprising.

When initially syncing data from an indexeddb provider, each update is applied independently.  This means any registered subscribers also receive the events one at a time, and can waste a lot of energy in the boot up process.  Instead, by wrapping the initialisation in a transaction, I can subscribe to the 'afterTransaction' event, and react only to the final, updated state.

I think maybe if you wait to register subscribers until the document has synced from indexeddb, then this is not an issue, but this change seems very helpful for me.