### PR TITLE
reverse clearData order

### DIFF
--- a/src/y-indexeddb.js
+++ b/src/y-indexeddb.js
@@ -132,8 +132,8 @@ export class IndexeddbPersistence extends Observable {
    * @return {Promise<void>}
    */
   clearData () {
-    return this.destroy().then(() => {
-      idb.deleteDB(this.name)
+    return idb.deleteDB(this.name).then(() => {
+      return this.destroy()
     })
   }
 


### PR DESCRIPTION
I'm encountering a weird race issue when calling `clearData`

- My call to `clearData` gets called, but results in a refresh of the current page (which is caused by the idb blocked handler)
- `onversionchange` never gets called

My assumption is that because `destroy()` calls `idb.close`, the `onversionchange` handler is never called. but at the same time, the idb handle is not really "closed" yet when we call deleteDB.

My solution would be to switch the order of the calls, see PR