### PR TITLE
fix early destroy

### DIFF
--- a/src/y-indexeddb.js
+++ b/src/y-indexeddb.js
@@ -57,6 +57,7 @@ export class IndexeddbPersistence extends Observable {
     this._mux = mutex.createMutex()
     this._dbref = 0
     this._dbsize = 0
+    this._destroyed = false
     /**
      * @type {IDBDatabase|null}
      */
@@ -75,6 +76,7 @@ export class IndexeddbPersistence extends Observable {
       this.db = db
       const currState = Y.encodeStateAsUpdate(doc)
       return fetchUpdates(this).then(updatesStore => idb.addAutoKey(updatesStore, currState)).then(() => {
+        if (this._destroyed) return this
         this.emit('synced', [this])
         this.synced = true
         return this
@@ -119,6 +121,7 @@ export class IndexeddbPersistence extends Observable {
     }
     this.doc.off('update', this._storeUpdate)
     this.doc.off('destroy', this.destroy)
+    this._destroyed = true
     return this._db.then(db => {
       db.close()
     })

--- a/tests/y-indexeddb.tests.js
+++ b/tests/y-indexeddb.tests.js
@@ -91,3 +91,18 @@ export const testMetaStorage = async tc => {
   const resC = await persistence.get('obj')
   t.compareObjects(resC, { a: 4 })
 }
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testEarlyDestroy = async tc => {
+  let hasbeenSyced = false
+  const ydoc = new Y.Doc()
+  const indexDBProvider = new IndexeddbPersistence(tc.testName, ydoc)
+  indexDBProvider.on('synced', () => {
+    hasbeenSyced = true
+  })
+  indexDBProvider.destroy()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  t.assert(!hasbeenSyced)
+}


### PR DESCRIPTION
This PR prevents `sync` when IndexedDBProvider has been destroyed.

fixes #20 
