### PR TITLE
Emit 'load' event on document when synced

### DIFF
--- a/src/y-indexeddb.js
+++ b/src/y-indexeddb.js
@@ -80,6 +80,7 @@ export class IndexeddbPersistence extends Observable {
       const beforeApplyUpdatesCallback = (updatesStore) => idb.addAutoKey(updatesStore, Y.encodeStateAsUpdate(doc))
       return fetchUpdates(this, beforeApplyUpdatesCallback).then(() => {
         if (this._destroyed) return this
+        this.doc.emit('load', [this.doc])
         this.emit('synced', [this])
         this.synced = true
         return this


### PR DESCRIPTION
I needed this event to use the `whenLoaded` promise, so I added it. Hope I got it right.

See this comment and the properties below:
https://github.com/yjs/yjs/blob/e0a2f11db325ae570ca273c4e75a1b9e8655491a/src/utils/Doc.js#L77

One could also add the `sync` event. I don't know what that would mean for IndexedDB, so I'll leave it as an excercise for the reader :)