### PR TITLE
Fixes #31

### DIFF
--- a/src/y-indexeddb.js
+++ b/src/y-indexeddb.js
@@ -84,7 +84,7 @@ export class IndexeddbPersistence extends Observable {
       /**
        * @param {IDBObjectStore} updatesStore
        */
-      const beforeApplyUpdatesCallback = (updatesStore) => idb.addAutoKey(updatesStore, Y.encodeStateAsUpdate(doc))
+      const beforeApplyUpdatesCallback = () => {}
       const afterApplyUpdatesCallback = () => {
         if (this._destroyed) return this
         this.synced = true


### PR DESCRIPTION
No need to add an update in the constructor because we are just loading the document. This commit adds a no-op `beforeApplyUpdatesCallback` handler to avoid creating a spurious update.