### PR TITLE
fix typo

### DIFF
--- a/src/y-indexeddb.js
+++ b/src/y-indexeddb.js
@@ -93,7 +93,7 @@ export class IndexeddbPersistence extends Observable {
       fetchUpdates(this, beforeApplyUpdatesCallback, afterApplyUpdatesCallback)
     })
     /**
-     * Timeout in ms untill data is merged and persisted in idb.
+     * Timeout in ms until data is merged and persisted in idb.
      */
     this._storeTimeout = 1000
     /**


### PR DESCRIPTION
This pull request includes a minor change to the `IndexeddbPersistence` class in the `src/y-indexeddb.js` file. The change corrects a typo in a comment, replacing "untill" with "until".

* [`src/y-indexeddb.js`](diffhunk://#diff-de8b1113484065be2a5c9bba1bbd32a58c808f4e821b555d4c37762a6d08e2d1L96-R96): Corrected typo in the comment for `_storeTimeout` property.